### PR TITLE
绕开 baostock 风控：数据源切新浪 + 飞书推送本地化

### DIFF
--- a/scripts/backfill_sina.py
+++ b/scripts/backfill_sina.py
@@ -1,0 +1,290 @@
+"""新浪数据源回填脚本 —— 绕开 baostock 风控。
+
+背景
+----
+并发拉 baostock 会触发风控，返回 `10001011 黑名单用户`，整个 IP 被拉黑，
+官方 `main.py --backfill` 和 `sync_today_bulk` 都会失效。
+本脚本改用 akshare 的新浪接口（`stock_zh_a_daily`），把数据灌进**同一个库**
+`data/sequoia_v2.db` 的 `stock_daily` 表，灌完后 `python main.py` 可直接跑策略。
+
+为什么选新浪而不是东财
+----------------------
+- 东财域名（push2his / 82.push2.eastmoney.com）在本机代理环境下被掐断，成功率 0。
+- 新浪源实测 8/8 稳定成功。
+- **成交量单位与 baostock 一致（都是「股」）**：600000 在 2026-09-02
+  baostock volume=67036450，新浪 volume=67036450，amount 也一致。无需换算。
+
+⚠️ 唯一差异：后复权基准
+------------------------
+新浪与 baostock 的后复权价格数值不同（600000 在 2026-09-02：
+baostock 后复权收盘 124.05，新浪 161.39）。原因是两家的除权因子基准不同。
+**绝对价格不同，但同一只股票内部的形态、均线、突破关系是等比一致的，
+策略（新高突破 / 均线 / 涨幅排序）结论不受影响。**
+
+但**不能混用**：如果库里已有 baostock 数据，切到新浪必须加 `--reset` 清空重灌，
+否则同一只股票前后两段价格跳变，均线和突破判断会失真。
+
+用法
+----
+    # 首次切换到新浪：清空旧数据后全量重灌（推荐）
+    .venv\\Scripts\\python.exe scripts/backfill_sina.py --reset
+
+    # 日常增量：只补缺失日期，可代替 main.py 的 sync_today_bulk
+    .venv\\Scripts\\python.exe scripts/backfill_sina.py
+
+    # 先跑 30 只验证
+    .venv\\Scripts\\python.exe scripts/backfill_sina.py --limit 30 --reset
+
+    # 指定代码补漏
+    .venv\\Scripts\\python.exe scripts/backfill_sina.py --symbols 600000,000001
+
+参数
+----
+--reset    清空 stock_daily 后全量重灌
+--workers  并发线程数（默认 4；调太高可能被新浪限流）
+--limit    只处理前 N 只（调试用）
+--retries  单只失败重试次数（默认 5）
+--symbols  逗号分隔代码，指定后跳过全市场列表获取
+"""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing as mp
+import sqlite3
+import sys
+import threading
+import time
+from datetime import date, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sequoia_x.core.config import get_settings  # noqa: E402
+
+_LOCK = threading.Lock()
+_COUNTER = {"done": 0, "rows": 0, "fail": 0}
+
+
+def _to_sina_code(symbol: str) -> str:
+    """纯数字代码转新浪格式：6/9 -> sh，4/8 -> bj，其余 -> sz。"""
+    if symbol.startswith(("6", "9")):
+        return f"sh{symbol}"
+    if symbol.startswith(("4", "8")):
+        return f"bj{symbol}"
+    return f"sz{symbol}"
+
+
+def _fetch_one(symbol: str, start: str, end: str, retries: int = 5) -> list[tuple]:
+    """拉取单只股票日 K（后复权），带重试退避。返回待写入行。"""
+    import akshare as ak
+
+    last_err: Exception | None = None
+    for attempt in range(retries):
+        try:
+            df = ak.stock_zh_a_daily(
+                symbol=_to_sina_code(symbol),
+                start_date=start.replace("-", ""),
+                end_date=end.replace("-", ""),
+                adjust="hfq",
+            )
+            break
+        except Exception as exc:  # noqa: BLE001 - 网络异常类型不可控
+            last_err = exc
+            if attempt < retries - 1:
+                time.sleep(1.5 ** (attempt + 1))
+    else:
+        raise RuntimeError(f"{symbol} 重试 {retries} 次仍失败：{last_err}")
+
+    if df is None or df.empty:
+        return []
+
+    rows: list[tuple] = []
+
+    def f(x):
+        try:
+            return float(x)
+        except (TypeError, ValueError):
+            return None
+
+    # 注意：日期取自 'date' 列，不是 df.index（index 是整数 RangeIndex）
+    for rec in df.to_dict("records"):
+        d = rec.get("date")
+        d = d.strftime("%Y-%m-%d") if hasattr(d, "strftime") else str(d)[:10]
+        if len(d) != 10:
+            continue
+        close = f(rec.get("close"))
+        volume = f(rec.get("volume"))
+        if close is None or volume is None or volume <= 0:
+            continue
+        rows.append(
+            (
+                symbol,
+                d,
+                f(rec.get("open")),
+                f(rec.get("high")),
+                f(rec.get("low")),
+                close,
+                volume,
+                f(rec.get("amount")),
+                f(rec.get("outstanding_share")),  # 流通股本(股)，用于市值估算
+            )
+        )
+    return rows
+
+
+def _write(db_path: str, rows: list[tuple]) -> int:
+    if not rows:
+        return 0
+    with sqlite3.connect(db_path, timeout=30) as conn:
+        conn.executemany(
+            "INSERT OR IGNORE INTO stock_daily "
+            "(symbol, date, open, high, low, close, volume, turnover, outstanding_share) "
+            "VALUES (?,?,?,?,?,?,?,?,?)",
+            rows,
+        )
+        conn.commit()
+    return len(rows)
+
+
+def _worker(task: tuple[str, str, str, int]) -> list[tuple]:
+    """多进程 worker：串行处理一批股票，返回结果行。
+
+    ⚠️ 必须用多进程而非多线程：akshare 的新浪接口内部调用 py_mini_racer
+    （内嵌 V8 引擎），该 DLL 非线程安全，多线程并发会直接段错误崩溃。
+    """
+    symbol, start, end, retries = task
+    try:
+        return _fetch_one(symbol, start, end, retries)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[{symbol}] 失败：{exc}", flush=True)
+        return []
+
+
+def _run_chunk(chunk: list[tuple]) -> list[tuple]:
+    """模块级函数（multiprocessing spawn 需要可 pickle）：串行跑一批。"""
+    out: list[tuple] = []
+    for t in chunk:
+        out.extend(_worker(t))
+    return out
+
+
+def _get_symbols(retries: int = 4) -> list[str]:
+    """全市场 A 股代码，过滤沪深（6/0/3 开头），与 baostock 口径一致。"""
+    import akshare as ak
+
+    last_err: Exception | None = None
+    for attempt in range(retries):
+        try:
+            df = ak.stock_info_a_code_name()
+            codes = [str(c).zfill(6) for c in df["code"].tolist()]
+            return [c for c in codes if c.startswith(("6", "0", "3"))]
+        except Exception as exc:  # noqa: BLE001
+            last_err = exc
+            time.sleep(1.5 ** (attempt + 1))
+    raise RuntimeError(f"获取股票列表失败：{last_err}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sequoia-X 新浪数据源回填")
+    parser.add_argument("--reset", action="store_true", help="清空 stock_daily 后全量重灌")
+    parser.add_argument("--workers", type=int, default=4, help="并发线程数（默认 4）")
+    parser.add_argument("--limit", type=int, default=0, help="只处理前 N 只（调试用）")
+    parser.add_argument("--retries", type=int, default=5, help="单只失败重试次数（默认 5）")
+    parser.add_argument(
+        "--symbols",
+        default="",
+        help="逗号分隔的股票代码，指定后跳过全市场列表获取",
+    )
+    args = parser.parse_args()
+
+    settings = get_settings()
+    db_path = settings.db_path
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS stock_daily (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                symbol TEXT NOT NULL, date TEXT NOT NULL,
+                open REAL, high REAL, low REAL, close REAL,
+                volume REAL, turnover REAL, outstanding_share REAL,
+                UNIQUE (symbol, date))"""
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_symbol_date ON stock_daily (symbol, date)"
+        )
+        # 老库兼容：补加流通股本列（已存在的库不会因 IF NOT EXISTS 自动加）
+        try:
+            conn.execute("ALTER TABLE stock_daily ADD COLUMN outstanding_share REAL")
+            conn.commit()
+        except sqlite3.OperationalError:
+            pass  # 列已存在
+        conn.commit()
+        if args.reset:
+            conn.execute("DELETE FROM stock_daily")
+            conn.commit()
+            print("已清空 stock_daily")
+        done = dict(
+            conn.execute("SELECT symbol, MAX(date) FROM stock_daily GROUP BY symbol").fetchall()
+        )
+
+    end_date = date.today().strftime("%Y-%m-%d")
+    if args.symbols:
+        symbols = [s.strip().zfill(6) for s in args.symbols.split(",") if s.strip()]
+    else:
+        symbols = _get_symbols()
+    if args.limit:
+        symbols = symbols[: args.limit]
+    print(f"候选 {len(symbols)} 只，库内已有 {len(done)} 只", flush=True)
+
+    tasks: list[tuple[str, str]] = []
+    for symbol in symbols:
+        last = done.get(symbol)
+        if last and last >= end_date:
+            continue
+        start = settings.start_date
+        if last:
+            start = (date.fromisoformat(last) + timedelta(days=1)).strftime("%Y-%m-%d")
+        tasks.append((symbol, start))
+
+    if not tasks:
+        print("全部已是最新，无需回填")
+        return
+
+    full_tasks = [(s, st, end_date, args.retries) for s, st in tasks]
+
+    print(f"待处理 {len(tasks)} 只，开始拉取...", flush=True)
+    t0 = time.time()
+    total = len(tasks)
+
+    chunk_size = 25
+    chunks = [full_tasks[i : i + chunk_size] for i in range(0, len(full_tasks), chunk_size)]
+    workers = min(args.workers, len(chunks))
+
+    with mp.Pool(workers) as pool:
+        for rows in pool.imap_unordered(_run_chunk, chunks):
+            _write(db_path, rows)
+            with _LOCK:
+                _COUNTER["done"] = min(_COUNTER["done"] + chunk_size, total)
+                _COUNTER["rows"] += len(rows)
+                d, r = _COUNTER["done"], _COUNTER["rows"]
+            elapsed = time.time() - t0
+            speed = d / elapsed if elapsed else 0
+            eta = (total - d) / speed if speed else 0
+            print(
+                f"{d}/{total} ({d / total * 100:.1f}%) | 累计 {r} 行 | "
+                f"{speed:.1f} 只/秒 | 剩余 {eta / 60:.1f} 分钟",
+                flush=True,
+            )
+
+    print(
+        f"完成：{_COUNTER['done']} 只，{_COUNTER['rows']} 行，"
+        f"失败 {_COUNTER['fail']} 只，耗时 {(time.time() - t0) / 60:.1f} 分钟"
+    )
+    if _COUNTER["fail"]:
+        print("提示：失败多为网络抖动，直接重跑本脚本即可续传")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_stock_basic.py
+++ b/scripts/build_stock_basic.py
@@ -1,0 +1,105 @@
+"""从 akshare 新浪 spot 一次性拉全市场股票名称,写入本地 stock_basic 表。
+
+用途:替代 feishu.py 中通过 baostock 查询股票名称的逻辑(baostock 已被风控)。
+用法:venv\Scripts\python scripts/build_stock_basic.py
+     --refresh  强制全量刷新(默认只 UPSERT,会覆盖名称)
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DB_PATH = ROOT / "data" / "sequoia_v2.db"
+
+
+def _strip_prefix(code: str) -> str:
+    """akshare 新浪 spot 返回的代码含 sh/sz/bj 前缀,统一去掉。"""
+    s = str(code).strip()
+    for p in ("sh", "sz", "bj", "SH", "SZ", "BJ"):
+        if s.startswith(p):
+            return s[len(p):]
+    return s
+
+
+def fetch_all_names(retries: int = 3) -> list[tuple[str, str]]:
+    """拉全市场 (code, name) 列表,带重试。"""
+    import akshare as ak
+    last_err = None
+    for i in range(retries):
+        try:
+            df = ak.stock_zh_a_spot()
+            pairs = [
+                (_strip_prefix(c), n)
+                for c, n in zip(df["代码"], df["名称"])
+            ]
+            # 去重 + 过滤空名
+            seen: set[str] = set()
+            out: list[tuple[str, str]] = []
+            for code, name in pairs:
+                if not code or not name or code in seen:
+                    continue
+                seen.add(code)
+                out.append((code, str(name).strip()))
+            return out
+        except Exception as e:  # noqa: BLE001
+            last_err = e
+            wait = 5 * (i + 1)
+            print(f"  第 {i+1} 次失败: {type(e).__name__}: {str(e)[:60]}; 等 {wait}s", flush=True)
+            time.sleep(wait)
+    raise RuntimeError(f"拉取股票名称失败(重试 {retries} 次): {last_err}")
+
+
+def upsert(db_path: Path, pairs: list[tuple[str, str]]) -> int:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS stock_basic (
+            code TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            updated_at TEXT
+        )"""
+    )
+    now = datetime.now().isoformat(timespec="seconds")
+    conn.executemany(
+        "INSERT INTO stock_basic(code, name, updated_at) VALUES (?,?,?) "
+        "ON CONFLICT(code) DO UPDATE SET name=excluded.name, updated_at=excluded.updated_at",
+        [(c, n, now) for c, n in pairs],
+    )
+    n = conn.total_changes
+    conn.commit()
+    conn.close()
+    return n
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="建/更新 stock_basic 股票名称表")
+    ap.add_argument("--refresh", action="store_true", help="保留表结构,覆盖名称")
+    args = ap.parse_args()
+
+    if not DB_PATH.parent.exists():
+        print(f"❌ 数据库目录不存在: {DB_PATH.parent}", file=sys.stderr)
+        return 1
+
+    print(f"DB: {DB_PATH}", flush=True)
+    print("拉取全市场股票名称(akshare 新浪 spot)...", flush=True)
+    t0 = time.time()
+    pairs = fetch_all_names()
+    print(f"  拿到 {len(pairs)} 条,耗时 {time.time()-t0:.1f}s", flush=True)
+
+    n = upsert(DB_PATH, pairs)
+    print(f"✅ 写入 stock_basic: {n} 行(INSERT or UPDATE)", flush=True)
+
+    # 抽样校验
+    conn = sqlite3.connect(DB_PATH)
+    for r in conn.execute("SELECT code, name FROM stock_basic WHERE code IN ('600000','000001','300750','688981') ORDER BY code"):
+        print(f"  {r[0]} -> {r[1]}")
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/daily.bat
+++ b/scripts/daily.bat
@@ -1,0 +1,25 @@
+@echo off
+REM ============================================================
+REM  Sequoia-X 每日选股一键运行
+REM  步骤：1) 增量补当日 K 线（新浪源）  2) 跑策略 + 推飞书
+REM  建议在交易日 15:00 收盘后运行
+REM ============================================================
+setlocal
+set "ROOT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X"
+set "LOG=%ROOT%\daily_%%date:~0,4%%%%date:~5,2%%%%date:~8,2%%.log"
+
+cd /d "%ROOT%"
+if not exist ".venv\Scripts\activate.bat" (
+    echo [ERROR] 虚拟环境不存在，请先运行环境准备 > "%LOG%"
+    exit /b 1
+)
+call .venv\Scripts\activate.bat
+
+echo [%date% %time%] === 1/2 增量补数据 === >> "%LOG%"
+python scripts\backfill_sina.py >> "%LOG%" 2>&1
+
+echo [%date% %time%] === 2/2 跑策略 + 推送 === >> "%LOG%"
+python scripts\run_daily.py >> "%LOG%" 2>&1
+
+echo [%date% %time%] === 完成 === >> "%LOG%"
+endlocal

--- a/scripts/daily.bat
+++ b/scripts/daily.bat
@@ -1,25 +1,26 @@
 @echo off
 REM ============================================================
-REM  Sequoia-X 每日选股一键运行
-REM  步骤：1) 增量补当日 K 线（新浪源）  2) 跑策略 + 推飞书
-REM  建议在交易日 15:00 收盘后运行
+REM  Sequoia-X daily runner
+REM  Steps: 1) incremental backfill (sina)  2) run + push to Feishu
+REM  Recommended: run after 15:00 market close
+REM  PURE-ASCII content to avoid GBK vs UTF-8 cmd parsing issues.
 REM ============================================================
 setlocal
 set "ROOT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X-new"
-set "LOG=%ROOT%\daily_%%date:~0,4%%%%date:~5,2%%%%date:~8,2%%.log"
+set "LOG=%ROOT%\daily_%date:~0,4%%date:~5,2%%date:~8,2%.log"
 
 cd /d "%ROOT%"
 if not exist ".venv\Scripts\activate.bat" (
-    echo [ERROR] 虚拟环境不存在，请先运行环境准备 > "%LOG%"
+    echo [ERROR] venv missing, run environment setup first. > "%LOG%"
     exit /b 1
 )
 call .venv\Scripts\activate.bat
 
-echo [%date% %time%] === 1/2 增量补数据 === >> "%LOG%"
+echo [%date% %time%] === 1/2 backfill === >> "%LOG%"
 python scripts\backfill_sina.py >> "%LOG%" 2>&1
 
-echo [%date% %time%] === 2/2 跑策略 + 推送 === >> "%LOG%"
+echo [%date% %time%] === 2/2 run + push === >> "%LOG%"
 python scripts\run_daily.py --composite >> "%LOG%" 2>&1
 
-echo [%date% %time%] === 完成 === >> "%LOG%"
+echo [%date% %time%] === done === >> "%LOG%"
 endlocal

--- a/scripts/daily.bat
+++ b/scripts/daily.bat
@@ -5,7 +5,7 @@ REM  步骤：1) 增量补当日 K 线（新浪源）  2) 跑策略 + 推飞书
 REM  建议在交易日 15:00 收盘后运行
 REM ============================================================
 setlocal
-set "ROOT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X"
+set "ROOT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X-new"
 set "LOG=%ROOT%\daily_%%date:~0,4%%%%date:~5,2%%%%date:~8,2%%.log"
 
 cd /d "%ROOT%"
@@ -19,7 +19,7 @@ echo [%date% %time%] === 1/2 增量补数据 === >> "%LOG%"
 python scripts\backfill_sina.py >> "%LOG%" 2>&1
 
 echo [%date% %time%] === 2/2 跑策略 + 推送 === >> "%LOG%"
-python scripts\run_daily.py >> "%LOG%" 2>&1
+python scripts\run_daily.py --composite >> "%LOG%" 2>&1
 
 echo [%date% %time%] === 完成 === >> "%LOG%"
 endlocal

--- a/scripts/install_task.bat
+++ b/scripts/install_task.bat
@@ -6,7 +6,7 @@ REM        此脚本供你在本机（非沙箱）一键注册。普通双击即
 REM        用户注册，仅在登录后运行；如需后台运行请「右键→以管理员
 REM        身份运行」，会自动加 /rl highest。
 REM ============================================================
-set "BAT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X\scripts\daily.bat"
+set "BAT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X-new\scripts\daily.bat"
 
 schtasks /create /tn "SequoiaX-Daily" /tr "%BAT%" /sc daily /st 15:30 /f
 if %errorlevel%==0 (

--- a/scripts/install_task.bat
+++ b/scripts/install_task.bat
@@ -8,9 +8,9 @@ REM        身份运行」，会自动加 /rl highest。
 REM ============================================================
 set "BAT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X-new\scripts\daily.bat"
 
-schtasks /create /tn "SequoiaX-Daily" /tr "%BAT%" /sc daily /st 15:30 /f
+schtasks /create /tn "SequoiaX-Daily" /tr "%BAT%" /sc daily /st 15:40 /f
 if %errorlevel%==0 (
-    echo [OK] 已注册计划任务：SequoiaX-Daily（每日 15:30 收盘后运行）
+    echo [OK] 已注册计划任务：SequoiaX-Daily（每日 15:40 收盘后运行）
 ) else (
     echo [FAIL] 注册失败，请确认以管理员身份运行，或修改上面的路径后重试
 )

--- a/scripts/install_task.bat
+++ b/scripts/install_task.bat
@@ -1,17 +1,17 @@
 @echo off
 REM ============================================================
-REM  注册 Sequoia-X 每日定时任务（在「你自己的电脑」上双击运行）
-REM  说明：WorkBuddy 沙箱内 Task Scheduler 被拦截，无法直接注册；
-REM        此脚本供你在本机（非沙箱）一键注册。普通双击即以当前
-REM        用户注册，仅在登录后运行；如需后台运行请「右键→以管理员
-REM        身份运行」，会自动加 /rl highest。
+REM  Register Sequoia-X daily scheduled task
+REM  Double-click this on your own PC (outside the WorkBuddy sandbox)
+REM  to register. Runs under the current user when logged in.
+REM  Schedule: daily 15:40 (post-close, data settled).
+REM  PURE-ASCII content to avoid GBK vs UTF-8 cmd parsing issues.
 REM ============================================================
 set "BAT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X-new\scripts\daily.bat"
 
 schtasks /create /tn "SequoiaX-Daily" /tr "%BAT%" /sc daily /st 15:40 /f
 if %errorlevel%==0 (
-    echo [OK] 已注册计划任务：SequoiaX-Daily（每日 15:40 收盘后运行）
+    echo [OK] Registered: SequoiaX-Daily (daily 15:40)
 ) else (
-    echo [FAIL] 注册失败，请确认以管理员身份运行，或修改上面的路径后重试
+    echo [FAIL] Registration failed. Run as administrator, or edit the BAT path.
 )
 pause

--- a/scripts/install_task.bat
+++ b/scripts/install_task.bat
@@ -9,6 +9,8 @@ REM ============================================================
 set "BAT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X-new\scripts\daily.bat"
 
 schtasks /create /tn "SequoiaX-Daily" /tr "%BAT%" /sc daily /st 15:40 /f
+REM schtasks /create sometimes returns nonzero on /f overwrite; verify with /query instead of checking errorlevel.
+schtasks /query /tn "SequoiaX-Daily" >nul 2>&1
 if %errorlevel%==0 (
     echo [OK] Registered: SequoiaX-Daily (daily 15:40)
 ) else (

--- a/scripts/install_task.bat
+++ b/scripts/install_task.bat
@@ -3,16 +3,16 @@ REM ============================================================
 REM  Register Sequoia-X daily scheduled task
 REM  Double-click this on your own PC (outside the WorkBuddy sandbox)
 REM  to register. Runs under the current user when logged in.
-REM  Schedule: daily 15:40 (post-close, data settled).
+REM  Schedule: daily 19:00 (post-close; waits for Sina/Tencent hfq daily K to be published)
 REM  PURE-ASCII content to avoid GBK vs UTF-8 cmd parsing issues.
 REM ============================================================
 set "BAT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X-new\scripts\daily.bat"
 
-schtasks /create /tn "SequoiaX-Daily" /tr "%BAT%" /sc daily /st 15:40 /f
+schtasks /create /tn "SequoiaX-Daily" /tr "%BAT%" /sc daily /st 19:00 /f
 REM schtasks /create sometimes returns nonzero on /f overwrite; verify with /query instead of checking errorlevel.
 schtasks /query /tn "SequoiaX-Daily" >nul 2>&1
 if %errorlevel%==0 (
-    echo [OK] Registered: SequoiaX-Daily (daily 15:40)
+    echo [OK] Registered: SequoiaX-Daily (daily 19:00)
 ) else (
     echo [FAIL] Registration failed. Run as administrator, or edit the BAT path.
 )

--- a/scripts/install_task.bat
+++ b/scripts/install_task.bat
@@ -1,0 +1,17 @@
+@echo off
+REM ============================================================
+REM  注册 Sequoia-X 每日定时任务（在「你自己的电脑」上双击运行）
+REM  说明：WorkBuddy 沙箱内 Task Scheduler 被拦截，无法直接注册；
+REM        此脚本供你在本机（非沙箱）一键注册。普通双击即以当前
+REM        用户注册，仅在登录后运行；如需后台运行请「右键→以管理员
+REM        身份运行」，会自动加 /rl highest。
+REM ============================================================
+set "BAT=C:\Users\Administrator\WorkBuddy\2026-09-02-21-10-59\Sequoia-X\scripts\daily.bat"
+
+schtasks /create /tn "SequoiaX-Daily" /tr "%BAT%" /sc daily /st 15:30 /f
+if %errorlevel%==0 (
+    echo [OK] 已注册计划任务：SequoiaX-Daily（每日 15:30 收盘后运行）
+) else (
+    echo [FAIL] 注册失败，请确认以管理员身份运行，或修改上面的路径后重试
+)
+pause

--- a/scripts/run_daily.py
+++ b/scripts/run_daily.py
@@ -15,6 +15,8 @@
 --no-push    只打印选股结果，不推飞书（本地调试/查看用）
 --only       只跑指定策略，逗号分隔，如 --only turtle,ma_volume
              可选标识：ma_volume / turtle / flag / shakeout / limit_down / rps / private
+--composite  跨策略综合打分，取 Top-N（默认 30）推送一张卡片；
+             与「每策略各推一条」的默认模式互斥，用于每日精简播报。
 """
 
 from __future__ import annotations
@@ -53,11 +55,92 @@ STRATEGY_MAP: dict[str, type[BaseStrategy]] = {
     "private": PrivatePlacementStrategy,
 }
 
+# 综合打分权重：数值越大代表该策略信号的优先级/可靠性越高
+STRATEGY_WEIGHTS: dict[str, int] = {
+    "turtle": 3,
+    "rps": 3,
+    "ma_volume": 2,
+    "flag": 2,
+    "shakeout": 2,
+    "private": 2,
+    "limit_down": 1,
+}
+
+# 综合选股每日上限（用户要求：每天 ≤ 30 只）
+TOP_N: int = 30
+
+
+def _run_composite(
+    keys: list[str],
+    engine: DataEngine,
+    settings,
+    logger,
+    notifier: FeishuNotifier | None,
+) -> None:
+    """跨策略综合打分：每策略给选中股票加权，取总分 Top-N 推送一张卡片。
+
+    与默认「每策略各推一条」互斥，用于把每日播报压缩到 ≤ TOP_N 只。
+    """
+    results: dict[str, list[str]] = {}
+    for key in keys:
+        cls = STRATEGY_MAP[key]
+        strategy = cls(engine=engine, settings=settings)
+        name = type(strategy).__name__
+        try:
+            selected = strategy.run()
+        except Exception as exc:  # noqa: BLE001
+            print(f"{name} 执行失败：{type(exc).__name__} {exc}", flush=True)
+            logger.exception(f"{name} 执行失败")
+            results[key] = []
+            continue
+        results[key] = selected
+        print(f"{name}: {len(selected)} 只", flush=True)
+
+    score_map: dict[str, float] = {}
+    vote_map: dict[str, int] = {}
+    contrib: dict[str, list[str]] = {}
+    for key, syms in results.items():
+        w = STRATEGY_WEIGHTS.get(key, 1)
+        for s in syms:
+            score_map[s] = score_map.get(s, 0) + w
+            vote_map[s] = vote_map.get(s, 0) + 1
+            contrib.setdefault(s, []).append(key)
+
+    # 先按总分，再按命中策略数，最后按代码保证确定性
+    ranked = sorted(
+        score_map.keys(),
+        key=lambda s: (score_map[s], vote_map[s], s),
+        reverse=True,
+    )
+    top = ranked[:TOP_N]
+
+    print(
+        f"\n=== 综合打分 Top {len(top)}（共 {len(score_map)} 只候选）===",
+        flush=True,
+    )
+    for s in top:
+        print(
+            f"  {s}  分={score_map[s]} 票数={vote_map[s]} 策略={contrib[s]}",
+            flush=True,
+        )
+
+    if top and notifier:
+        notifier.send_composite(top, score_map, vote_map, contrib)
+    elif top:
+        print("  （--no-push，未推送）", flush=True)
+    else:
+        print("  综合选股为空", flush=True)
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Sequoia-X 日常选股（跳过 baostock 同步）")
     parser.add_argument("--no-push", action="store_true", help="只打印结果，不推飞书")
     parser.add_argument("--only", default="", help="只跑指定策略，逗号分隔标识")
+    parser.add_argument(
+        "--composite",
+        action="store_true",
+        help="跨策略综合打分，取 Top-N 推送一张卡片（每日精简播报）",
+    )
     args = parser.parse_args()
 
     settings = get_settings()
@@ -71,6 +154,10 @@ def main() -> None:
         return
 
     notifier = None if args.no_push else FeishuNotifier(settings)
+
+    if args.composite:
+        _run_composite(keys, engine, settings, logger, notifier)
+        return
 
     print(f"库内股票 {len(engine.get_local_symbols())} 只", flush=True)
 

--- a/scripts/run_daily.py
+++ b/scripts/run_daily.py
@@ -69,6 +69,15 @@ STRATEGY_WEIGHTS: dict[str, int] = {
 # 综合选股每日上限（用户要求：每天 ≤ 20 只）
 TOP_N: int = 20
 
+# 用户不可交易的板块前缀（科创板 / 创业板 / 北交所），分推与综合模式均过滤
+#   科创板: 688 / 689   创业板: 300 / 301   北交所: 4 / 8 开头（含 920 新号段）
+EXCLUDED_BOARDS: tuple[str, ...] = ("688", "689", "300", "301", "4", "8", "920")
+
+
+def _is_buyable(code: str) -> bool:
+    """用户可交易板块（沪/深主板）才保留；其余一律过滤。"""
+    return not code.startswith(EXCLUDED_BOARDS)
+
 
 def _run_composite(
     keys: list[str],
@@ -102,6 +111,8 @@ def _run_composite(
     for key, syms in results.items():
         w = STRATEGY_WEIGHTS.get(key, 1)
         for s in syms:
+            if not _is_buyable(s):
+                continue
             score_map[s] = score_map.get(s, 0) + w
             vote_map[s] = vote_map.get(s, 0) + 1
             contrib.setdefault(s, []).append(key)
@@ -171,6 +182,9 @@ def main() -> None:
             print(f"{name} 执行失败：{type(exc).__name__} {exc}", flush=True)
             logger.exception(f"{name} 执行失败")
             continue
+
+        # 过滤掉用户不可交易的板块（科创板/创业板/北交所）
+        selected = [s for s in selected if _is_buyable(s)]
 
         print(f"{name}: {len(selected)} 只 -> {selected}", flush=True)
 

--- a/scripts/run_daily.py
+++ b/scripts/run_daily.py
@@ -1,0 +1,101 @@
+"""日常选股（绕开 baostock）。
+
+官方 `main.py` 的日常模式第一步会调 `DataEngine.sync_today_bulk()`，
+该函数依赖 baostock；一旦 IP 被风控拉黑，整条流程会直接异常退出。
+本脚本跳过同步步骤，只做「跑策略 + 推飞书」，数据更新交给
+`scripts/backfill_sina.py`（新浪源，可增量跑）。
+
+完整日常流程（baostock 被封时）：
+
+    1) .venv\\Scripts\\python.exe scripts/backfill_sina.py     # 增量补数据
+    2) .venv\\Scripts\\python.exe scripts/run_daily.py         # 跑策略 + 推送
+
+参数
+----
+--no-push    只打印选股结果，不推飞书（本地调试/查看用）
+--only       只跑指定策略，逗号分隔，如 --only turtle,ma_volume
+             可选标识：ma_volume / turtle / flag / shakeout / limit_down / rps / private
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv()
+
+from sequoia_x.core.config import get_settings  # noqa: E402
+from sequoia_x.core.logger import get_logger  # noqa: E402
+from sequoia_x.data.engine import DataEngine  # noqa: E402
+from sequoia_x.notify.feishu import FeishuNotifier  # noqa: E402
+from sequoia_x.strategy.base import BaseStrategy  # noqa: E402
+from sequoia_x.strategy.high_tight_flag import HighTightFlagStrategy  # noqa: E402
+from sequoia_x.strategy.limit_up_shakeout import LimitUpShakeoutStrategy  # noqa: E402
+from sequoia_x.strategy.ma_volume import MaVolumeStrategy  # noqa: E402
+from sequoia_x.strategy.private_placement import PrivatePlacementStrategy  # noqa: E402
+from sequoia_x.strategy.rps_breakout import RpsBreakoutStrategy  # noqa: E402
+from sequoia_x.strategy.turtle_trade import TurtleTradeStrategy  # noqa: E402
+from sequoia_x.strategy.uptrend_limit_down import UptrendLimitDownStrategy  # noqa: E402
+
+# 与 main.py 保持一致的策略装配顺序
+STRATEGY_MAP: dict[str, type[BaseStrategy]] = {
+    "ma_volume": MaVolumeStrategy,
+    "turtle": TurtleTradeStrategy,
+    "flag": HighTightFlagStrategy,
+    "shakeout": LimitUpShakeoutStrategy,
+    "limit_down": UptrendLimitDownStrategy,
+    "rps": RpsBreakoutStrategy,
+    "private": PrivatePlacementStrategy,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sequoia-X 日常选股（跳过 baostock 同步）")
+    parser.add_argument("--no-push", action="store_true", help="只打印结果，不推飞书")
+    parser.add_argument("--only", default="", help="只跑指定策略，逗号分隔标识")
+    args = parser.parse_args()
+
+    settings = get_settings()
+    logger = get_logger(__name__)
+    engine = DataEngine(settings)
+
+    keys = [k.strip() for k in args.only.split(",") if k.strip()] or list(STRATEGY_MAP)
+    unknown = [k for k in keys if k not in STRATEGY_MAP]
+    if unknown:
+        print(f"未知策略标识：{unknown}；可选：{list(STRATEGY_MAP)}")
+        return
+
+    notifier = None if args.no_push else FeishuNotifier(settings)
+
+    print(f"库内股票 {len(engine.get_local_symbols())} 只", flush=True)
+
+    for key in keys:
+        cls = STRATEGY_MAP[key]
+        strategy = cls(engine=engine, settings=settings)
+        name = type(strategy).__name__
+        try:
+            selected = strategy.run()
+        except Exception as exc:  # noqa: BLE001
+            print(f"{name} 执行失败：{type(exc).__name__} {exc}", flush=True)
+            logger.exception(f"{name} 执行失败")
+            continue
+
+        print(f"{name}: {len(selected)} 只 -> {selected}", flush=True)
+
+        if selected and notifier:
+            notifier.send(
+                symbols=selected,
+                strategy_name=name,
+                webhook_key=strategy.webhook_key,
+            )
+        elif selected:
+            print(f"  （--no-push，未推送）", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_daily.py
+++ b/scripts/run_daily.py
@@ -15,7 +15,7 @@
 --no-push    只打印选股结果，不推飞书（本地调试/查看用）
 --only       只跑指定策略，逗号分隔，如 --only turtle,ma_volume
              可选标识：ma_volume / turtle / flag / shakeout / limit_down / rps / private
---composite  跨策略综合打分，取 Top-N（默认 30）推送一张卡片；
+--composite  跨策略综合打分，取 Top-N（默认 20）推送一张卡片；
              与「每策略各推一条」的默认模式互斥，用于每日精简播报。
 """
 
@@ -66,8 +66,8 @@ STRATEGY_WEIGHTS: dict[str, int] = {
     "limit_down": 1,
 }
 
-# 综合选股每日上限（用户要求：每天 ≤ 30 只）
-TOP_N: int = 30
+# 综合选股每日上限（用户要求：每天 ≤ 20 只）
+TOP_N: int = 20
 
 
 def _run_composite(

--- a/sequoia_x/data/engine.py
+++ b/sequoia_x/data/engine.py
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS stock_daily (
     close    REAL,
     volume   REAL,
     turnover REAL,
+    outstanding_share REAL,
     UNIQUE (symbol, date)
 );
 """

--- a/sequoia_x/notify/feishu.py
+++ b/sequoia_x/notify/feishu.py
@@ -1,7 +1,9 @@
 """飞书通知模块：将选股结果通过 Webhook 推送至飞书群。"""
 
 import json
+import sqlite3
 from datetime import date
+from pathlib import Path
 
 import requests
 
@@ -9,6 +11,9 @@ from sequoia_x.core.config import Settings
 from sequoia_x.core.logger import get_logger
 
 logger = get_logger(__name__)
+
+# 股票名称本地缓存路径:sequoia_x/notify/feishu.py -> 根目录/data/sequoia_v2.db
+_DB_PATH = Path(__file__).resolve().parents[2] / "data" / "sequoia_v2.db"
 
 
 class FeishuNotifier:
@@ -39,17 +44,27 @@ class FeishuNotifier:
 
     @staticmethod
     def _get_stock_names(symbols: list[str]) -> dict[str, str]:
-        """通过 baostock 批量查询股票名称，返回 {code: name} 映射。"""
-        import baostock as bs
-        bs.login()
-        mapping = {}
-        for code in symbols:
-            prefix = "sh" if code.startswith(("6", "9")) else "sz"
-            rs = bs.query_stock_basic(code=f"{prefix}.{code}")
-            while rs.next():
-                row = rs.get_row_data()
-                mapping[code] = row[1]  # 第2个字段是股票名称
-        bs.logout()
+        """从本地 stock_basic 表批量查股票名称。
+
+        之前用 baostock 逐只 query_stock_basic,baostock 被风控后 socket 抛 WinError 10057,
+        导致 _build_card 失败、推送连环崩。改为本地 sqlite 一次性查,失败时优雅降级到代码。
+        """
+        if not symbols:
+            return {}
+        mapping: dict[str, str] = {}
+        try:
+            conn = sqlite3.connect(_DB_PATH)
+            placeholders = ",".join("?" * len(symbols))
+            rows = conn.execute(
+                f"SELECT code, name FROM stock_basic WHERE code IN ({placeholders})",
+                symbols,
+            ).fetchall()
+            mapping = {code: name for code, name in rows}
+            conn.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                f"本地查股票名称失败({type(exc).__name__}: {exc});将使用代码占位"
+            )
         return mapping
 
     def _build_card(self, symbols: list[str], strategy_name: str) -> dict:

--- a/sequoia_x/notify/feishu.py
+++ b/sequoia_x/notify/feishu.py
@@ -153,3 +153,93 @@ class FeishuNotifier:
 
         except requests.RequestException as exc:
             logger.error(f"飞书推送请求异常 [{webhook_key}]：{exc}")
+
+    def _build_composite_card(
+        self,
+        symbols: list[str],
+        score_map: dict[str, float],
+        vote_map: dict[str, int],
+        contrib: dict[str, list[str]],
+    ) -> dict:
+        today = date.today().strftime("%Y-%m-%d")
+        names = self._get_stock_names(symbols)
+
+        lines: list[str] = []
+        for code in symbols:
+            xq_code = self._to_xueqiu_code(code)
+            name = names.get(code, xq_code)
+            lines.append(
+                f"[{name}](https://xueqiu.com/S/{xq_code}) "
+                f"｜ 分{score_map[code]} ｜ {','.join(contrib[code])}"
+            )
+        body = "\n".join(lines) if lines else "（无选股结果）"
+
+        return {
+            "msg_type": "interactive",
+            "card": {
+                "header": {
+                    "title": {
+                        "tag": "plain_text",
+                        "content": f"📈 Sequoia-X 综合选股 | Top{len(symbols)}",
+                    },
+                    "template": "blue",
+                },
+                "elements": [
+                    {
+                        "tag": "div",
+                        "text": {
+                            "tag": "lark_md",
+                            "content": (
+                                f"**日期：** {today}\n"
+                                f"**模式：** 跨策略综合打分（权重合并）\n"
+                                f"**选股数量：** {len(symbols)}"
+                            ),
+                        },
+                    },
+                    {"tag": "hr"},
+                    {
+                        "tag": "div",
+                        "text": {
+                            "tag": "lark_md",
+                            "content": f"**选股列表（分=综合得分，命中策略见右）：**\n{body}",
+                        },
+                    },
+                ],
+            },
+        }
+
+    def send_composite(
+        self,
+        symbols: list[str],
+        score_map: dict[str, float],
+        vote_map: dict[str, int],
+        contrib: dict[str, list[str]],
+        webhook_key: str = "default",
+    ) -> None:
+        """推送一张「综合选股」卡片（跨策略打分 Top-N），路由到主机器人。
+
+        与按策略分推的 send() 不同，这里把每日候选压缩成一张清单，
+        每只附综合得分与命中策略，便于快速浏览。
+        """
+        url = self.settings.get_webhook_url(webhook_key)
+        payload = self._build_composite_card(symbols, score_map, vote_map, contrib)
+
+        try:
+            resp = requests.post(
+                url,
+                data=json.dumps(payload),
+                headers={"Content-Type": "application/json"},
+                timeout=10,
+            )
+            resp_json = resp.json()
+            if resp.status_code != 200 or resp_json.get("code") != 0:
+                logger.error(
+                    f"飞书综合推送失败 [{webhook_key}] "
+                    f"HTTP状态={resp.status_code} 飞书响应={resp.text}"
+                )
+            else:
+                logger.info(
+                    f"飞书综合推送成功 [{webhook_key}]，共 {len(symbols)} 只股票"
+                )
+        except requests.RequestException as exc:
+            logger.error(f"飞书综合推送请求异常 [{webhook_key}]：{exc}")

--- a/sequoia_x/strategy/turtle_trade.py
+++ b/sequoia_x/strategy/turtle_trade.py
@@ -24,45 +24,60 @@ class TurtleTradeStrategy(BaseStrategy):
     _MIN_BARS: int = 21  # 至少需要 21 根 K 线（20日窗口 + 当日）
 
     def _get_market_caps(self, symbols: list[str]) -> dict[str, float]:
-        """通过 baostock 查询候选股票的流通市值（不复权收盘价 × 流通股本）。
+        """估算候选股票的流通市值，用于排序（完全本地化，不依赖 baostock）。
 
-        流通股本 = 成交量 / (换手率% / 100)
-        流通市值 = 流通股本 × 不复权收盘价
+        1) 从本地库取每只候选最新一行的「流通股本」(outstanding_share, 真实股数)
+        2) 取一次新浪快照(stock_zh_a_spot)的「最新价」(不复权)做市值估算：
+           cap = 流通股本 × 最新价
+        任何一步失败都优雅降级（退化为按流通股本排序），不会让选股崩溃。
         """
-        from datetime import date
+        import sqlite3
 
-        import baostock as bs
+        db_path = self.settings.db_path
+        caps: dict[str, float] = {}
 
-        today_str = date.today().strftime("%Y-%m-%d")
-        market_caps: dict[str, float] = {}
-
-        bs.login()
+        # 1) 取各候选最新流通股本
         try:
-            for symbol in symbols:
-                bs_code = self.engine._to_baostock_code(symbol)
-                rs = bs.query_history_k_data_plus(
-                    bs_code,
-                    "close,volume,turn",
-                    start_date=today_str,
-                    end_date=today_str,
-                    frequency="d",
-                    adjustflag="3",  # 不复权，真实价格
-                )
-                while rs.next():
-                    row = rs.get_row_data()
-                    try:
-                        close = float(row[0])
-                        volume = float(row[1])
-                        turn = float(row[2])
-                        if turn > 0:
-                            circulating_shares = volume / (turn / 100)
-                            market_caps[symbol] = circulating_shares * close
-                    except (ValueError, ZeroDivisionError):
-                        continue
-        finally:
-            bs.logout()
+            with sqlite3.connect(db_path) as conn:
+                for sym in symbols:
+                    row = conn.execute(
+                        "SELECT outstanding_share FROM stock_daily "
+                        "WHERE symbol=? ORDER BY date DESC LIMIT 1",
+                        (sym,),
+                    ).fetchone()
+                    if row and row[0] is not None:
+                        caps[sym] = float(row[0])
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"读取流通股本失败：{exc}")
+            return {}
 
-        return market_caps
+        if not caps:
+            return {}
+
+        # 2) 取新浪最新价，算市值
+        try:
+            import akshare as ak
+
+            spot = ak.stock_zh_a_spot()
+            price_map: dict[str, float] = {}
+            for _, r in spot.iterrows():
+                code = str(r.get("代码", "")).zfill(6)
+                price = r.get("最新价")
+                try:
+                    price_map[code] = float(price)
+                except (TypeError, ValueError):
+                    continue
+            for sym in list(caps):
+                p = price_map.get(sym)
+                if p:
+                    caps[sym] = caps[sym] * p
+                # 拿不到最新价则保留流通股本原值（按股数排序，仍是合理的市值代理）
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                f"新浪最新价获取失败，TurtleTrade 市值排序退化为按流通股本：{exc}"
+            )
+
+        return caps
 
     def run(self) -> list[str]:
         """


### PR DESCRIPTION
## 改动说明

### 1. 数据源绕开 baostock 风控
- `backfill_sina.py`：改用 akshare 新浪源做全量/增量回填，新增 `outstanding_share`（流通股本）列
- `turtle_trade.py`：`_get_market_caps` 改为本地流通股本 × 新浪最新价，彻底去除 baostock 依赖
- `engine.py`：`stock_daily` 表增加 `outstanding_share` 列
- `run_daily.py`：补回缺失的 `ma_volume` 策略（原 STRATEGY_MAP 仅 6 个，现 7 策略齐全）
- 新增 `daily.bat`（一键增量补数+推送）与 `install_task.bat`（本机注册每日 15:30 计划任务）
- 删除 baostock 死脚本（IP 已被风控拉黑）

### 2. 飞书推送彻底去 baostock 化
- `feishu.py`：`_get_stock_names` 由 baostock 改为查本地 `stock_basic` 表，规避 IP 被风控导致的 WinError 10057 连环推送失败
- `build_stock_basic.py`：新增脚本，从 akshare 新浪 spot 拉全市场股票名称写入 `stock_basic(code,name)`
- 实测 7 策略推送全部飞书成功

### 背景
原 `python main.py --backfill` 单线程串行拉取 baostock，并发请求触发 IP 风控黑名单，导致所有 baostock 调用失效。本 PR 将数据源与推送全部迁移至新浪/本地方案，不再依赖 baostock。