### PR TITLE
fix: 修复测试套件失败与 SQLite 连接泄漏

### DIFF
--- a/sequoia_x/data/engine.py
+++ b/sequoia_x/data/engine.py
@@ -1,6 +1,8 @@
 """数据引擎模块：负责 SQLite 行情数据存储与 baostock 增量同步。"""
 
 import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pandas as pd
@@ -9,6 +11,28 @@ from sequoia_x.core.config import Settings
 from sequoia_x.core.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+@contextmanager
+def _connect(db_path: str) -> Iterator[sqlite3.Connection]:
+    """打开 SQLite 连接，退出时提交事务并**关闭连接**。
+
+    `with sqlite3.connect(...)` 只负责提交/回滚事务，并不关闭连接——
+    连接要等垃圾回收才释放。这会导致：
+      - Windows 上文件句柄未释放，临时数据库文件无法删除（测试失败）
+      - 常驻进程（Web 服务）中每次查询都残留一个连接，句柄持续累积
+
+    因此数据层统一通过本函数获取连接，不要直接写 `with sqlite3.connect(...)`。
+
+    Yields:
+        sqlite3.Connection: 事务语义与原先一致（正常退出提交，异常回滚）。
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        with conn:
+            yield conn
+    finally:
+        conn.close()
 
 
 _CREATE_TABLE_SQL = """
@@ -63,14 +87,14 @@ class DataEngine:
 
     def _init_db(self) -> None:
         Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
-        with sqlite3.connect(self.db_path) as conn:
+        with _connect(self.db_path) as conn:
             conn.execute(_CREATE_TABLE_SQL)
             conn.execute(_CREATE_INDEX_SQL)
             conn.commit()
         logger.info(f"数据库初始化完成：{self.db_path}")
 
     def _get_last_date(self, symbol: str) -> str | None:
-        with sqlite3.connect(self.db_path) as conn:
+        with _connect(self.db_path) as conn:
             row = conn.execute(
                 "SELECT MAX(date) FROM stock_daily WHERE symbol = ?",
                 (symbol,),
@@ -78,7 +102,7 @@ class DataEngine:
         return row[0] if row and row[0] else None
 
     def get_ohlcv(self, symbol: str) -> pd.DataFrame:
-        with sqlite3.connect(self.db_path) as conn:
+        with _connect(self.db_path) as conn:
             df = pd.read_sql(
                 "SELECT * FROM stock_daily WHERE symbol = ? ORDER BY date",
                 conn,
@@ -102,7 +126,7 @@ class DataEngine:
         today_str = date.today().strftime("%Y-%m-%d")
 
         tasks = []
-        with sqlite3.connect(self.db_path) as conn:
+        with _connect(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT symbol, MAX(date) FROM stock_daily GROUP BY symbol"
             ).fetchall()
@@ -146,7 +170,7 @@ class DataEngine:
         df = df[df["volume"] > 0]
 
         count = len(df)
-        with sqlite3.connect(self.db_path) as conn:
+        with _connect(self.db_path) as conn:
             for d in df["date"].unique().tolist():
                 conn.execute("DELETE FROM stock_daily WHERE date = ?", (d,))
             df.to_sql("stock_daily", conn, if_exists="append", index=False, method="multi", chunksize=500)
@@ -275,7 +299,7 @@ class DataEngine:
                 df = df[["symbol", "date", "open", "high", "low", "close", "volume", "turnover"]]
 
                 try:
-                    with sqlite3.connect(self.db_path) as conn:
+                    with _connect(self.db_path) as conn:
                         df.to_sql(
                             "stock_daily", conn, if_exists="append",
                             index=False, method="multi", chunksize=500,
@@ -326,7 +350,7 @@ class DataEngine:
             bs.logout()
 
     def get_local_symbols(self) -> list[str]:
-        with sqlite3.connect(self.db_path) as conn:
+        with _connect(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT DISTINCT symbol FROM stock_daily"
             ).fetchall()

--- a/tests/test_data_engine.py
+++ b/tests/test_data_engine.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 import tempfile
+from contextlib import closing
 from datetime import date
 from pathlib import Path
 
@@ -40,7 +41,9 @@ def test_unique_symbol_date_constraint(symbol: str, trade_date: date) -> None:
             "volume": 1000.0, "turnover": 10500.0,
         }
         df = pd.DataFrame([row])
-        with sqlite3.connect(engine.db_path) as conn:
+        # closing() 必不可少：`with sqlite3.connect()` 只提交事务，不关闭连接，
+        # 未关闭的句柄会让 Windows 上的 TemporaryDirectory 清理失败。
+        with closing(sqlite3.connect(engine.db_path)) as conn, conn:
             df.to_sql("stock_daily", conn, if_exists="append", index=False, method="multi")
             try:
                 df.to_sql("stock_daily", conn, if_exists="append", index=False, method="multi")

--- a/tests/test_feishu.py
+++ b/tests/test_feishu.py
@@ -4,7 +4,6 @@ import json
 import logging
 from unittest.mock import MagicMock, patch
 
-import pytest
 from hypothesis import given, settings as h_settings
 from hypothesis import strategies as st
 
@@ -20,6 +19,16 @@ def make_settings(webhook_url: str = "https://example.com/default") -> Settings:
     )
 
 
+def patch_stock_names(mapping: dict[str, str] | None = None):
+    """屏蔽 _build_card 内部的 baostock 股票名称查询。
+
+    _get_stock_names 会对每个 symbol 发一次真实网络请求，测试必须拦掉：
+    否则用例既慢又依赖外网（曾导致 hypothesis DeadlineExceeded）。
+    名称缺失时 _build_card 会退回展示雪球代码，断言不受影响。
+    """
+    return patch.object(FeishuNotifier, "_get_stock_names", return_value=mapping or {})
+
+
 # Feature: sequoia-x-v2, Property 10: 飞书通知包含所有选股结果
 @given(
     symbols=st.lists(
@@ -33,7 +42,7 @@ def test_notification_contains_all_symbols(symbols: list[str]) -> None:
     settings = make_settings()
     notifier = FeishuNotifier(settings)
 
-    with patch("requests.post") as mock_post:
+    with patch_stock_names(), patch("requests.post") as mock_post:
         mock_post.return_value = MagicMock(status_code=200)
         notifier.send(symbols=symbols, strategy_name="TestStrategy")
 
@@ -54,7 +63,7 @@ def test_notification_uses_config_url(webhook_url: str) -> None:
     settings = make_settings(webhook_url=webhook_url)
     notifier = FeishuNotifier(settings)
 
-    with patch("requests.post") as mock_post:
+    with patch_stock_names(), patch("requests.post") as mock_post:
         mock_post.return_value = MagicMock(status_code=200)
         notifier.send(symbols=["000001"], strategy_name="Test", webhook_key="default")
 
@@ -67,27 +76,26 @@ def test_notification_uses_config_url(webhook_url: str) -> None:
 @h_settings(max_examples=50)
 def test_http_failure_logs_error(status_code: int) -> None:
     """属性 12：非 200 响应时，send() 应记录 ERROR 级别日志，不抛出异常。"""
-    import logging as _logging
     import sequoia_x.notify.feishu as feishu_module
 
     settings = make_settings()
     notifier = FeishuNotifier(settings)
 
     # feishu logger 设置了 propagate=False，需直接在其上挂 handler
-    feishu_logger = _logging.getLogger(feishu_module.__name__)
-    log_records: list[_logging.LogRecord] = []
+    feishu_logger = logging.getLogger(feishu_module.__name__)
+    log_records: list[logging.LogRecord] = []
 
-    class _ListHandler(_logging.Handler):
-        def emit(self, record: _logging.LogRecord) -> None:
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
             log_records.append(record)
 
-    handler = _ListHandler(_logging.ERROR)
+    handler = _ListHandler(logging.ERROR)
     feishu_logger.addHandler(handler)
     try:
-        with patch("requests.post") as mock_post:
+        with patch_stock_names(), patch("requests.post") as mock_post:
             mock_post.return_value = MagicMock(status_code=status_code, text="error")
             notifier.send(symbols=["000001"], strategy_name="Test")
     finally:
         feishu_logger.removeHandler(handler)
 
-    assert any(r.levelno == _logging.ERROR for r in log_records)
+    assert any(r.levelno == logging.ERROR for r in log_records)


### PR DESCRIPTION
## 问题

在当前 master 上执行 `pytest`，6 个用例中有 5 个失败（Windows）：

```
FAILED tests/test_data_engine.py::test_unique_symbol_date_constraint - PermissionError
FAILED tests/test_strategy.py::test_strategy_run_returns_list_of_str - PermissionError
FAILED tests/test_feishu.py::test_notification_contains_all_symbols - DeadlineExceeded
FAILED tests/test_feishu.py::test_notification_uses_config_url - DeadlineExceeded
FAILED tests/test_feishu.py::test_http_failure_logs_error - DeadlineExceeded
5 failed, 4 passed in 58.27s
```

两个独立的根因。

## 1. SQLite 连接未关闭（`fix(data)`）

`with sqlite3.connect(...)` 只负责提交/回滚事务，**并不关闭连接**——连接要等垃圾回收才释放。影响：

- Windows 上文件句柄未释放，`TemporaryDirectory` 清理失败，两个用例报 `PermissionError`（Linux 上不复现，可能因此一直未被发现）
- 任何常驻进程中，每次查询都会残留一个连接，句柄持续累积

新增 `_connect()` 上下文管理器：退出时先提交事务再关闭连接，**事务语义与原先完全一致**（正常退出提交，异常回滚）。数据层 7 处调用点与测试中 1 处统一改用它。

## 2. 飞书测试实际在调用 baostock（`fix(test)`）

`_build_card` 会通过 `_get_stock_names` 为每个 symbol 发一次 baostock 网络请求。三个飞书用例没有拦截它，导致用例真实依赖外网、单次耗时约 2.5s，超出 hypothesis 默认 200ms deadline。

该网络调用是随「恢复飞书推送中的股票名称」一并引入的，当时未同步更新测试桩。新增 `patch_stock_names()` 统一屏蔽；名称缺失时 `_build_card` 会退回展示雪球代码，三条断言均不受影响。

顺带移除该文件中两个未使用的导入（`logging`、`pytest`）。

## 结果

```
9 passed in 4.14s
```

| | 修复前 | 修复后 |
|---|---|---|
| 测试 | 5 failed, 4 passed | **9 passed** |
| 耗时 | 58s | 4s |
| ruff | 48 | 45 |

- 无行为变更，未改动任何业务逻辑
- 两个 commit 相互独立，可分开 review 或单独取用
- 每个 commit 均已单独验证可通过测试

## 验证方式

`ruff` 数量通过 `git worktree` 检出 `444c0db` 逐条比对，确认无新增问题。